### PR TITLE
Version bump to 1.0.0-alpha

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}
+  version: "1.0.0.alpha"
 
 source:
   path: ..  # Points to the repository root

--- a/src/spectoprep/__init__.py
+++ b/src/spectoprep/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
 
 __author__ = """Habeeb Babatunde"""
 __email__ = 'babatundehabeeb2@gmail.com'
-__version__ = '0.1.0'
+__version__ = "1.0.0-alpha"


### PR DESCRIPTION
This PR bumps the version from 0.1.0 to 1.0.0-alpha.

Conda package version: 1.0.0.alpha

Once merged, a tag will be created and a release will be published.

**IMPORTANT:** Please review and merge this PR manually. Do not use auto-merge.

## Changelog Preview
```markdown
# Changelog

All notable changes to this project will be documented in this file.

## [1.0.0] - 2025-05-04

### Chore
* chore: bump version to 1.0.0-alpha (b30c6d9)

...
```