### PR TITLE
Version bump to 1.0.1-alpha

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spectoprep" %}
 {% set pypi_name = "spectoprep" %}
-{% set version = "1.0.0.alpha" %}   # This will be dynamically updated during CI/CD
+{% set version = "1.0.1.alpha" %}   # This will be dynamically updated during CI/CD
 
 package:
   name: {{ name|lower }}

--- a/src/spectoprep/__init__.py
+++ b/src/spectoprep/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
 
 __author__ = """Habeeb Babatunde"""
 __email__ = 'babatundehabeeb2@gmail.com'
-__version__ = "1.0.0-alpha"
+__version__ = "1.0.1-alpha"


### PR DESCRIPTION
This PR bumps the version from 1.0.0-alpha to 1.0.1-alpha.

Conda package version: 1.0.1.alpha

Once merged, a tag will be created and a release will be published.

**IMPORTANT:** Please review and merge this PR manually. Do not use auto-merge.

## Changelog Preview
```
Changelog
=========

All notable changes to this project will be documented in this file.

1.0.1 - 2025-05-05
----------------

Chore
~~~~~
* chore: bump version to 1.0.1-alpha (6e8eb73)

...
```